### PR TITLE
DNSサーバー追加

### DIFF
--- a/terraform/enviroment/dev/ansible.cfg
+++ b/terraform/enviroment/dev/ansible.cfg
@@ -1,2 +1,2 @@
-[ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+[defaults]
+host_key_checking = false

--- a/terraform/enviroment/dev/ansible.tf
+++ b/terraform/enviroment/dev/ansible.tf
@@ -9,6 +9,9 @@ resource "ansible_playbook" "playbook" {
     ansible_become               = true
     ansible_become_pass          = var.password
   }
+  depends_on = [
+    sakuracloud_server.web_srv
+  ]
 }
 
 output "args" {

--- a/terraform/enviroment/dev/dns.tf
+++ b/terraform/enviroment/dev/dns.tf
@@ -4,8 +4,7 @@ resource "sakuracloud_dns" "main" {
 
 resource "sakuracloud_dns_record" "main" {
   dns_id = sakuracloud_dns.main.id
-  name   = "www"
+  name   = "@"
   type   = "A"
-  value  = var.server.web.private_ip
-
+  value  = sakuracloud_server.web_srv.ip_address
 }

--- a/terraform/enviroment/dev/dns.tf
+++ b/terraform/enviroment/dev/dns.tf
@@ -1,0 +1,11 @@
+resource "sakuracloud_dns" "main" {
+  zone = var.domain
+}
+
+resource "sakuracloud_dns_record" "main" {
+  dns_id = sakuracloud_dns.main.id
+  name   = "www"
+  type   = "A"
+  value  = var.server.web.private_ip
+
+}

--- a/terraform/enviroment/dev/server.tf
+++ b/terraform/enviroment/dev/server.tf
@@ -9,22 +9,23 @@ resource "sakuracloud_disk" "web" {
   plan              = "ssd"
   connector         = "virtio"
   source_archive_id = data.sakuracloud_archive.ubuntu.id
+  zone              = var.default_zone
 }
 
 # 作成するサーバを定義
 resource "sakuracloud_server" "web_srv" {
-  name        = "web_srv"
+  name        = "${var.service}-${var.env}web_srv"
   disks       = [sakuracloud_disk.web.id]
   core        = 1
   memory      = 1
   description = "web server"
+  zone        = var.default_zone
 
-
-  # サーバのNICの接続先の定義。共有セグメント
   # ルータ+スイッチに置き換え予定
   network_interface {
-    upstream        = "shared"
-    user_ip_address = var.server.web.private_ip
+    upstream = "shared"
+    #upstream        = sakuracloud_switch.main.id
+    #user_ip_address = var.server.web.private_ip
   }
   # USER:ubuntu
   # Change root : sudo su - 

--- a/terraform/enviroment/dev/server.tf
+++ b/terraform/enviroment/dev/server.tf
@@ -23,7 +23,8 @@ resource "sakuracloud_server" "web_srv" {
   # サーバのNICの接続先の定義。共有セグメント
   # ルータ+スイッチに置き換え予定
   network_interface {
-    upstream = "shared"
+    upstream        = "shared"
+    user_ip_address = var.server.web.private_ip
   }
   # USER:ubuntu
   # Change root : sudo su - 

--- a/terraform/enviroment/dev/switch.tf
+++ b/terraform/enviroment/dev/switch.tf
@@ -1,0 +1,5 @@
+resource "sakuracloud_switch" "main" {
+  name        = "${var.service}-${var.env}-sw"
+  description = "Switch of ${var.env} for ${var.service}"
+  zone        = var.default_zone
+}

--- a/terraform/enviroment/dev/variable.tf
+++ b/terraform/enviroment/dev/variable.tf
@@ -1,8 +1,25 @@
+variable "domain" {
+  type    = string
+  default = "ppscan.org"
+}
+
 variable "password" {
   default   = "p@ssw0rd"
   type      = string
   sensitive = true
 }
+
+variable "server" {
+  type = map(object({
+    private_ip = string
+  }))
+  default = {
+    "web" = {
+      "private_ip" = "192.168.0.10"
+    }
+  }
+}
+
 
 variable "default_region" {
   type        = string

--- a/terraform/enviroment/dev/variable.tf
+++ b/terraform/enviroment/dev/variable.tf
@@ -1,6 +1,6 @@
 variable "domain" {
   type    = string
-  default = "ppscan.org"
+  default = "dev.ppscan.org"
 }
 
 variable "password" {
@@ -43,4 +43,10 @@ variable "env" {
   type        = string
   description = "環境名"
   default     = "dev"
+}
+
+variable "default_zone" {
+  type        = string
+  description = "デフォルトゾーン"
+  default     = "is1a" // 第一リージョン機能制限が入っているためis1b(石狩第２ゾーンが良い）
 }


### PR DESCRIPTION
## 対応内容

- さくらのクラウドのDNSアライアンスにゾーン・レコードを追加
- さくらのドメインで追加したDNSを`dev.`を付与してNSへ移譲
- digの結果、`A`レコードで疎通することまで確認
- スイッチも追加したが、外向きのネットワークへの接続はしていない状態（ルータの設定が必要だが、PoC用の環境待ち）

![image](https://github.com/user-attachments/assets/45118f81-13d4-486c-8631-1d856dd8650b)

![image](https://github.com/user-attachments/assets/18edebf3-0b68-4bcd-b59d-46ba950060ff)

![image](https://github.com/user-attachments/assets/6fecc162-382a-4cab-a5f5-7bc28e469c3b)


## 要確認

さくらのドメインのドメインコントローラ（Whois)にて`さくらのクラウド`のDNSへNSを書き換えたら、疎通できなかった
さくらのドメインで登録したドメインをさくらのクラウドのDNSでそのまま使う方法を確認が必要